### PR TITLE
Hide turntable locator during playblast

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -9,6 +9,12 @@ Release Notes
 
 .. release:: upcoming
 
+    .. change:: fix
+        :tags: maya
+
+        Hide turntable locator during playblast
+
+
     .. change:: new
         :tags: maya
 

--- a/resource/plugins/maya/python/publisher/exporters/maya_turntable_publisher_exporter.py
+++ b/resource/plugins/maya/python/publisher/exporters/maya_turntable_publisher_exporter.py
@@ -90,6 +90,8 @@ class MayaTurntablePublisherExporterPlugin(plugin.MayaPublisherExporterPlugin):
             name="object_locator",
         )
 
+        cmds.setAttr(object_locator[0] + ".visibility", False)
+
         up_axis = cmds.upAxis(q=True, axis=True)
         rotate_attribute = 'rotate{}'.format(up_axis.upper())
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-3mej3n6

- [ ] I have added automatic tests where applicable.
- [X] The PR contains a description of what has been changed.
- [X] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Hide turntable locator during playblast

## Test

Publish geometry in Maya, the reviewable should not contain the green locator marker.
            