### PR TITLE
Python definitions discoverable from DCCs

### DIFF
--- a/resource/definitions/register.py
+++ b/resource/definitions/register.py
@@ -12,11 +12,11 @@ logger = logging.getLogger('ftrack_connect_pipeline_definition.register')
 
 
 def register_definitions(session, event):
-    host_type = event['data']['pipeline']['host_type']
+    host_types = event['data']['pipeline']['host_types']
     current_dir = os.path.dirname(__file__)
     # collect definitions
     data = ftrack_connect_pipeline.definition.collect_and_validate(
-        session, current_dir, host_type
+        session, current_dir, host_types
     )
     return data
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/3c7bfda

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [ ] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
Support multiple host types on register_definitions.

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
        
From any DCC that has the host type set as [python, <name of the dcc>] you should be able to see the python definitions as well in any client, like for example the publisher.    
** This PR is related with https://github.com/ftrackhq/ftrack-connect-pipeline/pull/6 and should be tested together**