### PR TITLE
opener and loader python plugins and definitions fixed

### DIFF
--- a/resource/definitions/loader/python/file-python-loader.json
+++ b/resource/definitions/loader/python/file-python-loader.json
@@ -30,7 +30,7 @@
           "plugins":[
             {
               "name": "Pick objects with suffix",
-              "plugin": "collector_test"
+              "plugin": "common_test_opener_collector"
             },
             {
               "name": "Collect components from context",

--- a/resource/definitions/opener/python/file-python-opener.json
+++ b/resource/definitions/opener/python/file-python-opener.json
@@ -43,8 +43,7 @@
           "plugins":[
             {
               "name": "importer",
-              "plugin": "common_passthrough_loader_importer",
-              "widget": "common_default_loader_importer",
+              "plugin": "common_passthrough_opener_importer",
               "options": {
                 "load_mode": "import"
               }
@@ -84,8 +83,7 @@
           "plugins":[
             {
               "name": "importer",
-              "plugin": "common_passthrough_loader_importer",
-              "widget": "common_default_loader_importer",
+              "plugin": "common_passthrough_opener_importer",
               "options": {
                 "load_mode": "import"
               }

--- a/resource/plugins/common/python/opener/collectors/common_test_opener_collector.py
+++ b/resource/plugins/common/python/opener/collectors/common_test_opener_collector.py
@@ -8,7 +8,7 @@ import ftrack_api
 class CollectorOpenerTest(plugin.OpenerCollectorPlugin):
     '''An empty test opener collector'''
 
-    plugin_name = 'collector_test'
+    plugin_name = 'common_test_opener_collector'
 
     def run(self, context_data=None, data=None, options=None):
         return []


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/3bp4zfw

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [ ] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
Loader and opener python definitions are now fixed and discoverable in standalone mode
## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            
Run standalone, should be able to discover loader and opener python definitions.