### PR TITLE
Make merge default load mode for Houdini loaders

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -12,6 +12,12 @@ Release Notes
     .. change:: new
         :tags: houdini
 
+        Make merge default load mode for Houdini loaders.
+
+
+    .. change:: new
+        :tags: houdini
+
         Houdini integration.
 
 
@@ -19,6 +25,7 @@ Release Notes
         :tags: definitions
 
         Allow registry definitions of multiple host_types.
+
 
     .. change:: fixed
         :tags: plugins

--- a/resource/definitions/loader/houdini/camera-houdini-loader.json
+++ b/resource/definitions/loader/houdini/camera-houdini-loader.json
@@ -42,7 +42,7 @@
               "name": "Import paths to Houdini",
               "plugin": "houdini_native_loader_importer",
               "options": {
-                "load_mode": "import",
+                "load_mode": "merge",
                 "load_options": {
                   "MergeOverwriteOnConflict": true
                 }
@@ -81,7 +81,7 @@
               "name": "Import paths to Houdini",
               "plugin": "houdini_native_loader_importer",
               "options": {
-                "load_mode": "import",
+                "load_mode": "merge",
                 "load_options": {
                   "MergeOverwriteOnConflict": true
                 }

--- a/resource/definitions/loader/houdini/geometry-houdini-loader.json
+++ b/resource/definitions/loader/houdini/geometry-houdini-loader.json
@@ -42,7 +42,7 @@
               "name": "Import paths to Houdini",
               "plugin": "houdini_native_loader_importer",
               "options": {
-                "load_mode": "import",
+                "load_mode": "merge",
                 "load_options": {
                   "MergeOverwriteOnConflict": true
                 }
@@ -81,7 +81,7 @@
               "name": "Import paths to Houdini",
               "plugin": "houdini_native_loader_importer",
               "options": {
-                "load_mode": "import",
+                "load_mode": "merge",
                 "load_options": {
                   "MergeOverwriteOnConflict": true
                 }

--- a/resource/definitions/loader/houdini/scene-houdini-loader.json
+++ b/resource/definitions/loader/houdini/scene-houdini-loader.json
@@ -42,7 +42,7 @@
               "name": "Import paths to Houdini",
               "plugin": "houdini_native_loader_importer",
               "options": {
-                "load_mode": "import",
+                "load_mode": "merge",
                 "load_options": {
                   "MergeOverwriteOnConflict": true
                 }


### PR DESCRIPTION
Resolves : 

* CLICKUP-https://app.clickup.com/t/3rj7pb4

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Make merge default load mode for Houdini loaders

## Test

Test assembler in Houdini, should suggest merge instead of import.
            