### PR TITLE
feat: Backlog/unreal/project context/show untracked dependencies in asset manager

### DIFF
--- a/resource/plugins/unreal/python/loader/finalizers/unreal_asset_loader_finalizer.py
+++ b/resource/plugins/unreal/python/loader/finalizers/unreal_asset_loader_finalizer.py
@@ -28,7 +28,7 @@ class UnrealAssetLoaderFinalizerPlugin(plugin.UnrealLoaderFinalizerPlugin):
         result = {}
 
         # First, evaluate asset path
-        asset_filesystem_path = component_path = None
+        asset_filesystem_path = None
         for comp in data:
             if comp['type'] == core_constants.COMPONENT:
                 for result in comp['result']:

--- a/resource/plugins/unreal/python/opener/finalizers/unreal_asset_opener_finalizer.py
+++ b/resource/plugins/unreal/python/opener/finalizers/unreal_asset_opener_finalizer.py
@@ -1,7 +1,6 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014-2022 ftrack
-import json
-
+import os
 import unreal
 
 import ftrack_api

--- a/resource/plugins/unreal/python/opener/importers/unreal_native_opener_importer.py
+++ b/resource/plugins/unreal/python/opener/importers/unreal_native_opener_importer.py
@@ -1,6 +1,9 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014-2022 ftrack
 import copy
+import os
+
+import unreal
 
 from ftrack_connect_pipeline.constants import asset as asset_const
 
@@ -39,15 +42,21 @@ class UnrealNativeOpenerImporterPlugin(plugin.UnrealOpenerImporterPlugin):
         for component_path in paths_to_import:
             self.logger.debug('Opening path: "{}"'.format(component_path))
 
-            load_result = load_mode_fn(
+            asset_filesystem_path = load_mode_fn(
                 component_path, unreal_options, self.session
             )
 
-            self.logger.debug(
-                'Imported Unreal asset to: "{}"'.format(load_result)
+            # Have Unreal discover the newly imported asset
+            assetRegistry = unreal.AssetRegistryHelpers.get_asset_registry()
+            assetRegistry.scan_paths_synchronous(
+                [os.path.dirname(asset_filesystem_path)], force_rescan=True
             )
 
-            results[component_path] = load_result
+            self.logger.debug(
+                'Imported Unreal asset to: "{}"'.format(asset_filesystem_path)
+            )
+
+            results[component_path] = asset_filesystem_path
 
         return results
 

--- a/resource/plugins/unreal/python/publisher/collectors/unreal_dependencies_publisher_collector.py
+++ b/resource/plugins/unreal/python/publisher/collectors/unreal_dependencies_publisher_collector.py
@@ -32,13 +32,11 @@ class UnrealLevelPublisherCollectorPlugin(
 
             asset_path = str(selected_asset_data[0].package_name)
 
-        else:
-            # Fetch from level
-            asset_path = str(
-                unreal.EditorLevelLibrary.get_editor_world().get_path_name()
-            )
+            return unreal_utils.get_asset_dependencies(asset_path)
 
-        return unreal_utils.get_asset_dependencies(asset_path)
+        else:
+            # Fetch level dependencies
+            return unreal_utils.get_level_dependencies()
 
     def add(self, context_data=None, data=None, options=None):
         '''Fetch the selected asset from content browser'''

--- a/resource/plugins/unreal/python/publisher/exporters/unreal_asset_publisher_exporter.py
+++ b/resource/plugins/unreal/python/publisher/exporters/unreal_asset_publisher_exporter.py
@@ -27,21 +27,12 @@ class UnrealAssetPublisherExporterPlugin(plugin.UnrealPublisherExporterPlugin):
         for collector in data:
             collected_objects.extend(collector['result'])
 
-        asset_asset_path = (
-            collected_objects[0].replace('/Game/', '').replace('/', os.sep)
+        asset_filesystem_path = unreal_utils.asset_path_to_filesystem_path(
+            collected_objects[0]
         )
         asset_dependencies = collected_objects[1:]
 
-        root_content_dir = (
-            unreal.SystemLibrary.get_project_content_directory().replace(
-                '/', os.sep
-            )
-        )
-        asset_path = unreal_utils.determine_extension(
-            os.path.join(root_content_dir, asset_asset_path)
-        )
-
-        return [asset_path], {'data': asset_dependencies}
+        return [asset_filesystem_path], {'data': asset_dependencies}
 
 
 def register(api_object, **kw):

--- a/resource/plugins/unreal/python/publisher/exporters/unreal_level_publisher_exporter.py
+++ b/resource/plugins/unreal/python/publisher/exporters/unreal_level_publisher_exporter.py
@@ -27,21 +27,12 @@ class UnrealLevelPublisherExporterPlugin(plugin.UnrealPublisherExporterPlugin):
         for collector in data:
             collected_objects.extend(collector['result'])
 
-        level_asset_path = (
-            collected_objects[0].replace('/Game/', '').replace('/', os.sep)
+        umap_filesystem_path = unreal_utils.asset_path_to_filesystem_path(
+            collected_objects[0]
         )
         level_dependencies = collected_objects[1:]
 
-        root_content_dir = (
-            unreal.SystemLibrary.get_project_content_directory().replace(
-                '/', os.sep
-            )
-        )
-        umap_path = unreal_utils.determine_extension(
-            os.path.join(root_content_dir, level_asset_path)
-        )
-
-        return [umap_path], {'data': level_dependencies}
+        return [umap_filesystem_path], {'data': level_dependencies}
 
 
 def register(api_object, **kw):

--- a/resource/plugins/unreal/python/publisher/post_finalizers/unreal_dependency_track_publisher_post_finalizer.py
+++ b/resource/plugins/unreal/python/publisher/post_finalizers/unreal_dependency_track_publisher_post_finalizer.py
@@ -85,7 +85,9 @@ class UnrealDependencyTrackPublisherFinalizerPlugin(
         loader defined in *options*.'''
 
         # Extract version ID from the run data
-        asset_version_id = component_name = asset_filesystem_path = None
+        asset_version_id = None
+        component_name = None
+        asset_filesystem_path = None
         for comp in data:
             if comp['type'] == core_constants.COMPONENT:
                 for result in comp['result']:


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-865bgyyrq


-->

Resolves <!--Task reference -->

## Changes

Fixed bug where component name and id were not provided in AM engine

## Test

_Note: has to be tested with corresponding PR on definition, qt and unreal._

Do a full cycle test on the asset manager, publishing assets with dependencies, loading them in another and test republish with update to latest version.