### PR TITLE
feat: Backlog/unreal/project context/shot publisher

### DIFF
--- a/resource/definitions/publisher/unreal/image-sequence-unreal-publish.json
+++ b/resource/definitions/publisher/unreal/image-sequence-unreal-publish.json
@@ -30,7 +30,7 @@
           "name": "collector",
           "plugins":[
             {
-              "name": "select sequence",
+              "name": "select level sequence",
               "plugin": "unreal_sequence_publisher_collector",
               "widget": "unreal_sequence_publisher_collector"
             }
@@ -65,7 +65,7 @@
           "name": "collector",
           "plugins":[
             {
-              "name": "select sequence",
+              "name": "select level sequence",
               "plugin": "unreal_sequence_publisher_collector",
               "widget": "unreal_sequence_publisher_collector"
             }

--- a/resource/definitions/publisher/unreal/image-sequence-unreal-publish.json
+++ b/resource/definitions/publisher/unreal/image-sequence-unreal-publish.json
@@ -30,7 +30,7 @@
           "name": "collector",
           "plugins":[
             {
-              "name": "select sequence to render",
+              "name": "select sequence",
               "plugin": "unreal_sequence_publisher_collector",
               "widget": "unreal_sequence_publisher_collector"
             }
@@ -65,7 +65,7 @@
           "name": "collector",
           "plugins":[
             {
-              "name": "select sequence to render",
+              "name": "select sequence",
               "plugin": "unreal_sequence_publisher_collector",
               "widget": "unreal_sequence_publisher_collector"
             }

--- a/resource/definitions/publisher/unreal/shot-unreal-publish.json
+++ b/resource/definitions/publisher/unreal/shot-unreal-publish.json
@@ -1,0 +1,135 @@
+{
+  "type": "publisher",
+  "name": "Shot Publisher",
+  "asset_type": "img",
+  "host_type": "unreal",
+  "ui_type": "qt",
+  "batch": true,
+  "contexts": [
+    {
+      "name": "main",
+      "stages": [
+        {
+          "name": "context",
+          "plugins":[
+            {
+              "name": "Unreal sequence context",
+              "plugin": "unreal_sequence_publisher_context",
+              "widget": "unreal_sequence_publisher_context",
+              "options": {
+                "selection": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "components": [
+    {
+      "name": "sequence",
+      "optional": true,
+      "stages": [
+        {
+          "name": "collector",
+          "plugins":[
+            {
+              "name": "collect shot(s) to render",
+              "plugin": "unreal_shot_publisher_collector"
+            }
+          ]
+        },
+        {
+          "name": "validator",
+          "plugins":[
+            {
+              "name": "validate selection",
+              "plugin": "common_non_empty_publisher_validator"
+            }
+          ]
+        },
+        {
+          "name": "exporter",
+          "plugins":[
+            {
+              "name": "write reviewable",
+              "plugin": "unreal_sequence_publisher_exporter",
+              "widget": "unreal_sequence_publisher_exporter"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "reviewable",
+      "optional": true,
+      "stages": [
+        {
+          "name": "collector",
+          "plugins":[
+            {
+              "name": "collect shot(s) to render",
+              "plugin": "unreal_shot_publisher_collector"
+            }
+          ]
+        },
+        {
+          "name": "validator",
+          "plugins":[
+            {
+              "name": "validate selection",
+              "plugin": "common_non_empty_publisher_validator"
+            }
+          ]
+        },
+        {
+          "name": "exporter",
+          "plugins":[
+            {
+              "name": "write reviewable",
+              "plugin": "unreal_reviewable_publisher_exporter",
+              "widget": "unreal_reviewable_publisher_exporter"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "finalizers": [
+    {
+      "name": "main",
+      "stages": [
+        {
+          "name": "pre_finalizer",
+          "visible": false,
+          "plugins":[
+            {
+              "name": "Pre publish to ftrack server",
+              "plugin": "common_passthrough_publisher_pre_finalizer"
+            }
+          ]
+        },
+        {
+          "name": "finalizer",
+          "visible": false,
+          "plugins":[
+            {
+              "name": "Publish to ftrack server",
+              "plugin": "common_passthrough_publisher_finalizer"
+            }
+          ]
+        },
+        {
+          "name": "post_finalizer",
+          "visible": false,
+          "plugins":[
+            {
+              "name": "Post process publish",
+              "plugin": "common_passthrough_publisher_post_finalizer"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/resource/definitions/publisher/unreal/shot-unreal-publish.json
+++ b/resource/definitions/publisher/unreal/shot-unreal-publish.json
@@ -34,8 +34,8 @@
           "name": "collector",
           "plugins":[
             {
-              "name": "collect shot(s) to render",
-              "plugin": "unreal_shot_publisher_collector"
+              "name": "select level sequence",
+              "plugin": "unreal_sequence_publisher_collector"
             }
           ]
         },
@@ -68,8 +68,8 @@
           "name": "collector",
           "plugins":[
             {
-              "name": "collect shot(s) to render",
-              "plugin": "unreal_shot_publisher_collector"
+              "name": "select level sequence",
+              "plugin": "unreal_sequence_publisher_collector"
             }
           ]
         },

--- a/resource/definitions/schema/publisher-schema.json
+++ b/resource/definitions/schema/publisher-schema.json
@@ -568,10 +568,11 @@
     "components",
     "finalizers",
     "type",
+    "batch",
     "_config"
   ],
   "order":[
-    "type", "name", "asset_type", "task_type", "host_type", "ui_type", "discoverable" ,"contexts", "components", "finalizers"
+    "type", "name", "asset_type", "task_type", "host_type", "ui_type", "batch", "discoverable" ,"contexts", "components", "finalizers"
   ],
   "properties": {
     "type": {
@@ -605,6 +606,10 @@
       "default": [
         "Task"
       ]
+    },
+    "batch": {
+      "type": "boolean",
+      "default": false
     },
     "contexts": {
       "type": "array",

--- a/resource/plugins/nuke/python/publisher/exporters/nuke_sequence_publisher_exporter.py
+++ b/resource/plugins/nuke/python/publisher/exporters/nuke_sequence_publisher_exporter.py
@@ -187,13 +187,11 @@ class NukeSequencePublisherExporterPlugin(plugin.NukePublisherExporterPlugin):
                     )
                     shutil.copy(source_path, destination_path)
 
-                sequence_path = '{} [{}-{}]'.format(
+                sequence_path = '{}'.format(
                     os.path.join(
                         temp_sequence_dir,
                         os.path.basename(file_node['file'].value()),
-                    ),
-                    int(file_node['first'].value()),
-                    int(file_node['last'].value()),
+                    )
                 )
         finally:
             # restore selection

--- a/resource/plugins/nuke/python/publisher/exporters/nuke_sequence_publisher_exporter.py
+++ b/resource/plugins/nuke/python/publisher/exporters/nuke_sequence_publisher_exporter.py
@@ -187,11 +187,13 @@ class NukeSequencePublisherExporterPlugin(plugin.NukePublisherExporterPlugin):
                     )
                     shutil.copy(source_path, destination_path)
 
-                sequence_path = '{}'.format(
+                sequence_path = '{} [{}-{}]'.format(
                     os.path.join(
                         temp_sequence_dir,
                         os.path.basename(file_node['file'].value()),
-                    )
+                    ),
+                    int(file_node['first'].value()),
+                    int(file_node['last'].value()),
                 )
         finally:
             # restore selection

--- a/resource/plugins/unreal/python/publisher/collectors/unreal_sequence_publisher_collector.py
+++ b/resource/plugins/unreal/python/publisher/collectors/unreal_sequence_publisher_collector.py
@@ -27,8 +27,8 @@ class UnrealSequencePublisherCollectorPlugin(
         '''Fetch all sequences from the level/map'''
         result = []
         collected_objects = unreal_utils.get_all_sequences()
-        # Mark the selected sequence
 
+        # Find the selected sequence
         seq_name_sel = None
         for actor in unreal.EditorLevelLibrary.get_selected_level_actors():
             if (
@@ -43,6 +43,7 @@ class UnrealSequencePublisherCollectorPlugin(
             if object == seq_name_sel:
                 data['default'] = True
             result.append(data)
+
         return result
 
     def run(self, context_data=None, data=None, options=None):

--- a/resource/plugins/unreal/python/publisher/context/unreal_sequence_publisher_context.py
+++ b/resource/plugins/unreal/python/publisher/context/unreal_sequence_publisher_context.py
@@ -23,7 +23,11 @@ class UnrealSequencePublisherContextPlugin(plugin.PublisherContextPlugin):
 
         try:
             shot = unreal_utils.push_shot_to_server(
-                sequence_context_id, shot_name, self.session
+                sequence_context_id,
+                shot_name,
+                self.session,
+                start=options.get('start'),
+                end=options.get('end'),
             )
             options['asset_parent_context_id'] = shot['id']
             self.logger.info(

--- a/resource/plugins/unreal/python/publisher/context/unreal_sequence_publisher_context.py
+++ b/resource/plugins/unreal/python/publisher/context/unreal_sequence_publisher_context.py
@@ -1,0 +1,49 @@
+# :coding: utf-8
+# :copyright: Copyright (c) 2014-2023 ftrack
+
+import ftrack_api
+
+from ftrack_connect_pipeline import plugin
+
+from ftrack_connect_pipeline_unreal.utils import (
+    custom_commands as unreal_utils,
+)
+
+
+class UnrealSequencePublisherContextPlugin(plugin.PublisherContextPlugin):
+    '''Unreal sequence publisher context plugin'''
+
+    plugin_name = 'unreal_sequence_publisher_context'
+
+    def run(self, context_data=None, data=None, options=None):
+        '''Find out the sequence context id and shot name and sync the shot to ftrack'''
+
+        shot_name = options.get('shot_name')
+        sequence_context_id = options.get('sequence_context_id')
+
+        try:
+            shot = unreal_utils.push_shot_to_server(
+                sequence_context_id, shot_name, self.session
+            )
+            options['asset_parent_context_id'] = shot['id']
+            self.logger.info(
+                'asset_build {} structure checks done'.format(shot['name'])
+            )
+        except Exception as e:
+            raise Exception(
+                'Failed to create sequence shot build for "{}", '
+                'please check your ftrack permissions and for any existing '
+                'entities in conflict.\n\nDetails: {}'.format(shot_name, e)
+            )
+
+        output = self.output
+        output.update(options)
+        return output
+
+
+def register(api_object, **kw):
+    if not isinstance(api_object, ftrack_api.Session):
+        # Exit to avoid registering this plugin again.
+        return
+    plugin = UnrealSequencePublisherContextPlugin(api_object)
+    plugin.register()

--- a/resource/plugins/unreal/python/publisher/exporters/unreal_reviewable_publisher_exporter.py
+++ b/resource/plugins/unreal/python/publisher/exporters/unreal_reviewable_publisher_exporter.py
@@ -1,6 +1,8 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014-2022 ftrack
 import os
+import tempfile
+import shutil
 
 import unreal
 
@@ -24,87 +26,105 @@ class UnrealReviewablePublisherExporterPlugin(
     def run(self, context_data=None, data=None, options=None):
         '''Export a Unreal reviewable from the selected sequence given
         in *data* and options given with *options*.'''
-        collected_objects = []
-        for collector in data:
-            collected_objects.extend(collector['result'])
 
-        master_sequence = None
+        if options.get('mode') == 'pickup':
 
-        seq_name = None
-        all_sequences = unreal_utils.get_all_sequences(as_names=False)
-        for _seq_name in collected_objects:
-            seq_name = _seq_name
-            for seq in all_sequences:
-                if seq.get_name() == _seq_name or _seq_name.startswith(
-                    '{}_'.format(seq.get_name())
-                ):
-                    master_sequence = seq
-                    break
-            if master_sequence:
-                break
+            file_path = options.get('file_path')
 
-        if master_sequence is None:
-            return False, {
-                'message': 'Sequence {} not found, please refresh publisher!'.format(
-                    seq_name
+            self.logger.debug(
+                'Using pre-rendered movie path: "{}", copying to temp.'.format(
+                    file_path
                 )
-            }
-
-        # Determine next expected version on context
-        next_version = 1
-        task = self.session.query(
-            'Task where id={}'.format(context_data['context_id'])
-        ).one()
-        asset = self.session.query(
-            'Asset where parent.id={} and name={}'.format(
-                task['parent']['id'], context_data['asset_name']
             )
-        ).first()
-        if asset:
-            latest_version = self.session.query(
-                'AssetVersion where asset.id={} and is_latest_version is "True"'.format(
-                    asset['id']
+
+            movie_path = tempfile.NamedTemporaryFile(
+                delete=False, suffix='.mov'
+            ).name
+
+            shutil.copy(file_path, movie_path)
+
+        else:
+            collected_objects = []
+            for collector in data:
+                collected_objects.extend(collector['result'])
+
+            master_sequence = None
+
+            seq_name = None
+            all_sequences = unreal_utils.get_all_sequences(as_names=False)
+            for _seq_name in collected_objects:
+                seq_name = _seq_name
+                for seq in all_sequences:
+                    if seq.get_name() == _seq_name or _seq_name.startswith(
+                        '{}_'.format(seq.get_name())
+                    ):
+                        master_sequence = seq
+                        break
+                if master_sequence:
+                    break
+
+            if master_sequence is None:
+                return False, {
+                    'message': 'Sequence {} not found, please refresh publisher!'.format(
+                        seq_name
+                    )
+                }
+
+            # Determine next expected version on context
+            next_version = 1
+            task = self.session.query(
+                'Task where id={}'.format(context_data['context_id'])
+            ).one()
+            asset = self.session.query(
+                'Asset where parent.id={} and name={}'.format(
+                    task['parent']['id'], context_data['asset_name']
                 )
             ).first()
-            if latest_version:
-                next_version = latest_version['version'] + 1
-        destination_path = os.path.join(
-            unreal.SystemLibrary.get_project_saved_directory(),
-            'VideoCaptures',
-            seq_name,
-            'v{}'.format(next_version),
-        )
-        self.logger.info(
-            'Rendering movie to next expected version folder: {}'.format(
-                destination_path
+            if asset:
+                latest_version = self.session.query(
+                    'AssetVersion where asset.id={} and is_latest_version is "True"'.format(
+                        asset['id']
+                    )
+                ).first()
+                if latest_version:
+                    next_version = latest_version['version'] + 1
+            destination_path = os.path.join(
+                unreal.SystemLibrary.get_project_saved_directory(),
+                'VideoCaptures',
+                seq_name,
+                'v{}'.format(next_version),
             )
-        )
+            self.logger.info(
+                'Rendering movie to next expected version folder: {}'.format(
+                    destination_path
+                )
+            )
 
-        unreal_map = unreal.EditorLevelLibrary.get_editor_world()
-        unreal_map_path = unreal_map.get_path_name()
-        unreal_asset_path = master_sequence.get_path_name()
+            unreal_map = unreal.EditorLevelLibrary.get_editor_world()
+            unreal_map_path = unreal_map.get_path_name()
+            unreal_asset_path = master_sequence.get_path_name()
 
-        asset_name = self._standard_structure.sanitise_for_filesystem(
-            context_data['asset_name']
-        )
+            asset_name = self._standard_structure.sanitise_for_filesystem(
+                context_data['asset_name']
+            )
 
-        movie_name = '{}_reviewable'.format(asset_name)
-        result = unreal_utils.render(
-            unreal_asset_path,
-            unreal_map_path,
-            movie_name,
-            destination_path,
-            master_sequence.get_display_rate().numerator,
-            unreal_utils.compile_capture_args(options),
-            self.logger,
-        )
+            movie_name = '{}_reviewable'.format(asset_name)
+            result = unreal_utils.render(
+                unreal_asset_path,
+                unreal_map_path,
+                movie_name,
+                destination_path,
+                master_sequence.get_display_rate().numerator,
+                unreal_utils.compile_capture_args(options),
+                self.logger,
+            )
 
-        if isinstance(result, tuple):
-            return result
+            if isinstance(result, tuple):
+                return result
 
-        path = result
+            movie_path = result
 
-        return [path]
+        return [movie_path]
 
 
 def register(api_object, **kw):

--- a/resource/plugins/unreal/python/publisher/exporters/unreal_sequence_publisher_exporter.py
+++ b/resource/plugins/unreal/python/publisher/exporters/unreal_sequence_publisher_exporter.py
@@ -57,13 +57,11 @@ class UnrealSequencePublisherExporterPlugin(
                 )
                 shutil.copy(source_path, destination_path)
 
-            new_file_path = '{} [{}-{}]'.format(
+            new_file_path = '{}'.format(
                 os.path.join(
                     temp_sequence_dir,
                     os.path.basename(file_path),
-                ),
-                first,
-                last,
+                )
             )
 
         else:

--- a/resource/plugins/unreal/python/publisher/exporters/unreal_sequence_publisher_exporter.py
+++ b/resource/plugins/unreal/python/publisher/exporters/unreal_sequence_publisher_exporter.py
@@ -1,6 +1,9 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014-2022 ftrack
 import os
+import clique
+import tempfile
+import shutil
 
 import unreal
 
@@ -25,100 +28,139 @@ class UnrealSequencePublisherExporterPlugin(
         '''Render and export a image file sequence from the selected sequence given
         in *data* and options given with *options*.'''
 
-        collected_objects = []
-        for collector in data:
-            collected_objects.extend(collector['result'])
+        if options.get('mode') == 'pickup':
 
-        master_sequence = None
+            file_path = options.get('file_path')
+            first = options.get('first')
+            last = options.get('last')
 
-        seq_name = None
-        all_sequences = unreal_utils.get_all_sequences(as_names=False)
-        for _seq_name in collected_objects:
-            seq_name = _seq_name
-            for seq in all_sequences:
-                if seq.get_name() == _seq_name or _seq_name.startswith(
-                    '{}_'.format(seq.get_name())
-                ):
-                    master_sequence = seq
-                    break
-            if master_sequence:
-                break
+            collections = clique.parse(file_path)
 
-        if master_sequence is None:
-            return False, {
-                'message': 'Sequence {} not found, please refresh publisher!'.format(
-                    seq_name
+            self.logger.debug(
+                'Using pre-rendered file sequence path: "{}", copying to temp.'.format(
+                    file_path
                 )
-            }
-
-        # Determine next expected version on context
-        next_version = 1
-        task = self.session.query(
-            'Task where id={}'.format(context_data['context_id'])
-        ).one()
-        asset = self.session.query(
-            'Asset where parent.id={} and name={}'.format(
-                task['parent']['id'], context_data['asset_name']
             )
-        ).first()
-        if asset:
-            latest_version = self.session.query(
-                'AssetVersion where asset.id={} and is_latest_version is "True"'.format(
-                    asset['id']
+
+            temp_sequence_dir = tempfile.mkdtemp()
+            if not os.path.exists(temp_sequence_dir):
+                os.makedirs(temp_sequence_dir)
+
+            # Copy sequence
+            for collection in collections:
+                source_path = str(collection)
+                destination_path = os.path.join(
+                    temp_sequence_dir, os.path.basename(source_path)
+                )
+                self.logger.debug(
+                    'Copying "{}" > "{}"'.format(source_path, destination_path)
+                )
+                shutil.copy(source_path, destination_path)
+
+            new_file_path = '{} [{}-{}]'.format(
+                os.path.join(
+                    temp_sequence_dir,
+                    os.path.basename(file_path),
+                ),
+                first,
+                last,
+            )
+
+        else:
+            collected_objects = []
+            for collector in data:
+                collected_objects.extend(collector['result'])
+
+            master_sequence = None
+
+            seq_name = None
+            all_sequences = unreal_utils.get_all_sequences(as_names=False)
+            for _seq_name in collected_objects:
+                seq_name = _seq_name
+                for seq in all_sequences:
+                    if seq.get_name() == _seq_name or _seq_name.startswith(
+                        '{}_'.format(seq.get_name())
+                    ):
+                        master_sequence = seq
+                        break
+                if master_sequence:
+                    break
+
+            if master_sequence is None:
+                return False, {
+                    'message': 'Sequence {} not found, please refresh publisher!'.format(
+                        seq_name
+                    )
+                }
+
+            # Determine next expected version on context
+            next_version = 1
+            task = self.session.query(
+                'Task where id={}'.format(context_data['context_id'])
+            ).one()
+            asset = self.session.query(
+                'Asset where parent.id={} and name={}'.format(
+                    task['parent']['id'], context_data['asset_name']
                 )
             ).first()
-            if latest_version:
-                next_version = latest_version['version'] + 1
-        destination_path = os.path.join(
-            unreal.SystemLibrary.get_project_saved_directory(),
-            'VideoCaptures',
-            seq_name,
-            'v{}'.format(next_version),
-        )
-        self.logger.info(
-            'Rendering sequence to next expected version folder: {}'.format(
-                destination_path
+            if asset:
+                latest_version = self.session.query(
+                    'AssetVersion where asset.id={} and is_latest_version is "True"'.format(
+                        asset['id']
+                    )
+                ).first()
+                if latest_version:
+                    next_version = latest_version['version'] + 1
+            destination_path = os.path.join(
+                unreal.SystemLibrary.get_project_saved_directory(),
+                'VideoCaptures',
+                seq_name,
+                'v{}'.format(next_version),
             )
-        )
+            self.logger.info(
+                'Rendering sequence to next expected version folder: {}'.format(
+                    destination_path
+                )
+            )
 
-        unreal_map = unreal.EditorLevelLibrary.get_editor_world()
-        unreal_map_path = unreal_map.get_path_name()
-        unreal_asset_path = master_sequence.get_path_name()
+            unreal_map = unreal.EditorLevelLibrary.get_editor_world()
+            unreal_map_path = unreal_map.get_path_name()
+            unreal_asset_path = master_sequence.get_path_name()
 
-        asset_name = self._standard_structure.sanitise_for_filesystem(
-            context_data['asset_name']
-        )
+            asset_name = self._standard_structure.sanitise_for_filesystem(
+                context_data['asset_name']
+            )
 
-        file_format = options.get('file_format', 'exr')
-        result = unreal_utils.render(
-            unreal_asset_path,
-            unreal_map_path,
-            asset_name,
-            destination_path,
-            master_sequence.get_display_rate().numerator,
-            unreal_utils.compile_capture_args(options),
-            self.logger,
-            image_format=file_format,
-        )
+            file_format = options.get('file_format', 'exr')
+            result = unreal_utils.render(
+                unreal_asset_path,
+                unreal_map_path,
+                asset_name,
+                destination_path,
+                master_sequence.get_display_rate().numerator,
+                unreal_utils.compile_capture_args(options),
+                self.logger,
+                image_format=file_format,
+            )
 
-        if isinstance(result, tuple):
-            return result
+            if isinstance(result, tuple):
+                return result
 
-        path = result
+            path = result
 
-        # try to get start and end frames from sequence this allow local
-        # control for test publish(subset of sequence)
-        frameStart = master_sequence.get_playback_start()
-        frameEnd = master_sequence.get_playback_end() - 1
-        base_file_path = (
-            path[:-12]
-            if path.endswith('.{frame}.%s' % (file_format))
-            else path
-        )
+            # try to get start and end frames from sequence this allow local
+            # control for test publish(subset of sequence)
+            frameStart = master_sequence.get_playback_start()
+            frameEnd = master_sequence.get_playback_end() - 1
+            base_file_path = (
+                path[:-12]
+                if path.endswith('.{frame}.%s' % (file_format))
+                else path
+            )
 
-        new_file_path = '{0}.%04d.{1} [{2}-{3}]'.format(
-            base_file_path, file_format, frameStart, frameEnd
-        )
+            new_file_path = '{0}.%04d.{1} [{2}-{3}]'.format(
+                base_file_path, file_format, frameStart, frameEnd
+            )
 
         return [new_file_path]
 

--- a/resource/plugins/unreal/python/publisher/exporters/unreal_sequence_publisher_exporter.py
+++ b/resource/plugins/unreal/python/publisher/exporters/unreal_sequence_publisher_exporter.py
@@ -25,14 +25,12 @@ class UnrealSequencePublisherExporterPlugin(
     _standard_structure = ftrack_api.structure.standard.StandardStructure()
 
     def run(self, context_data=None, data=None, options=None):
-        '''Render and export a image file sequence from the selected sequence given
+        '''Render and export an image file sequence from the selected sequence given
         in *data* and options given with *options*.'''
 
         if options.get('mode') == 'pickup':
 
             file_path = options.get('file_path')
-            first = options.get('first')
-            last = options.get('last')
 
             collections = clique.parse(file_path)
 

--- a/resource/plugins/unreal/python/publisher/exporters/widget/unreal_reviewable_publisher_exporter_options.py
+++ b/resource/plugins/unreal/python/publisher/exporters/widget/unreal_reviewable_publisher_exporter_options.py
@@ -105,7 +105,7 @@ class UnrealReviewablePublisherExporterOptionsWidget(DynamicWidget):
         self.layout().addWidget(self.render_rb)
 
         if not 'mode' in self.options:
-            self.set_option_result('pickup', 'mode')  # Set default mode
+            self.set_option_result('render', 'mode')  # Set default mode
         mode = self.options['mode'].lower()
         if mode == 'pickup':
             self.pickup_rb.setChecked(True)
@@ -149,7 +149,10 @@ class UnrealReviewablePublisherExporterOptionsWidget(DynamicWidget):
         else:
             start_dir = os.path.dirname(self._render_folder_input.text())
 
-        movie_path = QtWidgets.QFileDialog.getOpenFileName(
+        (
+            movie_path,
+            unused_selected_filter,
+        ) = QtWidgets.QFileDialog.getOpenFileName(
             caption='Choose rendered movie file',
             dir=start_dir,
             filter='Avi file (*.avi)',

--- a/resource/plugins/unreal/python/publisher/exporters/widget/unreal_reviewable_publisher_exporter_options.py
+++ b/resource/plugins/unreal/python/publisher/exporters/widget/unreal_reviewable_publisher_exporter_options.py
@@ -87,6 +87,8 @@ class UnrealReviewablePublisherExporterOptionsWidget(DynamicWidget):
 
         self._render_folder_input = QtWidgets.QLineEdit(
             '<please choose a movie>'
+            if not 'file_path' in self.options
+            else self.options['file_path']
         )
         self._render_folder_input.setReadOnly(True)
 

--- a/resource/plugins/unreal/python/publisher/exporters/widget/unreal_sequence_publisher_exporter_options.py
+++ b/resource/plugins/unreal/python/publisher/exporters/widget/unreal_sequence_publisher_exporter_options.py
@@ -1,15 +1,20 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2022 ftrack
+# :copyright: Copyright (c) 2014-2023 ftrack
+import os
 
-from functools import partial
+from Qt import QtWidgets, QtCore, QtGui
 
-from ftrack_connect_pipeline_unreal import plugin
-from ftrack_connect_pipeline_qt.plugin.widget.dynamic import DynamicWidget
-from ftrack_connect_pipeline_qt.ui.utility.widget import group_box
-
-from Qt import QtWidgets, QtCore
+import unreal
 
 import ftrack_api
+
+from ftrack_connect_pipeline_qt.plugin.widget.dynamic import DynamicWidget
+from ftrack_connect_pipeline_qt.ui.utility.widget import dialog
+
+from ftrack_connect_pipeline_unreal import plugin
+from ftrack_connect_pipeline_unreal.utils import (
+    custom_commands as unreal_utils,
+)
 
 
 class UnrealSequencePublisherExporterOptionsWidget(DynamicWidget):
@@ -72,8 +77,109 @@ class UnrealSequencePublisherExporterOptionsWidget(DynamicWidget):
         # Update current options with the given ones from definitions and store
         self.update(self.define_options())
 
+        bg = QtWidgets.QButtonGroup(self)
+
+        self.pickup_rb = QtWidgets.QRadioButton('Pick up rendered sequence')
+        bg.addButton(self.pickup_rb)
+        self.layout().addWidget(self.pickup_rb)
+
+        # TODO: Store video capture output folder in Unreal project
+        self._choose_folder_widget = QtWidgets.QWidget()
+        self._choose_folder_widget.setLayout(QtWidgets.QHBoxLayout())
+        self._choose_folder_widget.layout().setContentsMargins(0, 0, 0, 0)
+        self._choose_folder_widget.layout().setSpacing(0)
+
+        self._choose_folder_widget.layout().addWidget(
+            QtWidgets.QLabel('Capture folder:')
+        )
+
+        self._render_folder_input = QtWidgets.QLineEdit(
+            '<please choose a folder>'
+        )
+        self._render_folder_input.setReadOnly(True)
+
+        self._choose_folder_widget.layout().addWidget(
+            self._render_folder_input, 20
+        )
+
+        self._browser_button = QtWidgets.QPushButton('BROWSE')
+        self._browser_button.setObjectName('borderless')
+
+        self._choose_folder_widget.layout().addWidget(self._browser_button)
+        self.layout().addWidget(self._choose_folder_widget)
+
+        self.render_rb = QtWidgets.QRadioButton('Render from sequence')
+        bg.addButton(self.render_rb)
+        self.layout().addWidget(self.render_rb)
+
+        if not 'mode' in self.options:
+            self.set_option_result('pickup', 'mode')  # Set default mode
+        mode = self.options['mode'].lower()
+        if mode == 'pickup':
+            self.pickup_rb.setChecked(True)
+        else:
+            self.render_rb.setChecked(True)
+
         # Call the super build to automatically generate the options
         super(UnrealSequencePublisherExporterOptionsWidget, self).build()
+
+    def post_build(self):
+        super(UnrealSequencePublisherExporterOptionsWidget, self).post_build()
+
+        self.render_rb.clicked.connect(self._update_render_mode)
+        self.pickup_rb.clicked.connect(self._update_render_mode)
+
+        self._update_render_mode()
+
+        self._browser_button.clicked.connect(self._show_file_dialog)
+
+    def _update_render_mode(self):
+        mode = 'render'
+        if self.pickup_rb.isChecked():
+            mode = 'pickup'
+        self.set_option_result(mode, 'mode')
+
+        self._choose_folder_widget.setVisible(mode == 'pickup')
+        self.option_group.setVisible(mode == 'render')
+
+    def _show_file_dialog(self):
+        '''Shows the file dialog'''
+
+        if self._render_folder_input.text() == '<please choose a folder>':
+            start_dir = os.path.realpath(
+                os.path.join(
+                    unreal.SystemLibrary.get_project_saved_directory(),
+                    "VideoCaptures",
+                )
+            )
+        else:
+            start_dir = os.path.dirname(self._render_folder_input.text())
+
+        path = QtWidgets.QFileDialog.getExistingDirectory(
+            caption='Choose directory containing rendered image sequence',
+            dir=start_dir,
+            options=QtWidgets.QFileDialog.ShowDirsOnly,
+        )
+
+        if not path:
+            return
+
+        sequence_path, first, last = unreal_utils.find_image_sequence(path)
+
+        if sequence_path:
+            self._render_folder_input.setText(sequence_path)
+            self._render_folder_input.setToolTip(sequence_path)
+            self.set_option_result(sequence_path, 'file_path')
+            self.set_option_result(first, 'first')
+            self.set_option_result(last, 'last')
+        else:
+            dialog.ModalDialog(
+                None,
+                title='Locate rendered image sequence',
+                message='An image sequence on the form "prefix.NNNN.ext" were not found in: {}!'.format(
+                    path
+                ),
+            )
 
 
 class UnrealSequencePublisherExporterOptionsPluginWidget(

--- a/resource/plugins/unreal/python/publisher/exporters/widget/unreal_sequence_publisher_exporter_options.py
+++ b/resource/plugins/unreal/python/publisher/exporters/widget/unreal_sequence_publisher_exporter_options.py
@@ -113,7 +113,7 @@ class UnrealSequencePublisherExporterOptionsWidget(DynamicWidget):
         self.layout().addWidget(self.render_rb)
 
         if not 'mode' in self.options:
-            self.set_option_result('pickup', 'mode')  # Set default mode
+            self.set_option_result('render', 'mode')  # Set default mode
         mode = self.options['mode'].lower()
         if mode == 'pickup':
             self.pickup_rb.setChecked(True)

--- a/resource/plugins/unreal/python/publisher/exporters/widget/unreal_sequence_publisher_exporter_options.py
+++ b/resource/plugins/unreal/python/publisher/exporters/widget/unreal_sequence_publisher_exporter_options.py
@@ -95,6 +95,8 @@ class UnrealSequencePublisherExporterOptionsWidget(DynamicWidget):
 
         self._render_folder_input = QtWidgets.QLineEdit(
             '<please choose a folder>'
+            if not 'file_path' in self.options
+            else self.options['file_path']
         )
         self._render_folder_input.setReadOnly(True)
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-865bkucw2


This PR has been tested on :

- [X] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

- Give artist ability to select a master sequence with shots, and publish them with batch publisher as image sequences and reviewables.

## Test

_Note: Must be tested with corresponding branch on definition, qt and unreal._

1. Create a master sequence with proper animated shots in Unreal.
2. Render the shots to a folder, with {shot} suffix to path.
3. Select the sequence in Level and run the ftrack Batch publisher.
4. Select a sequence from ftrack, and the folder rendered to (capture folder).
5. Run the batch publisher, shots should be created in ftrack with image sequence/movie asset versions.